### PR TITLE
jx-python-flask-docker to 0.0.8

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.89
+- name: jx-python-flask-docker
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.8
 - name: python-flask-docker
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote jx-python-flask-docker to version 0.0.8