### PR TITLE
python-flask-docker to 0.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,4 +12,4 @@ dependencies:
   version: 0.0.8
 - name: python-flask-docker
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.6


### PR DESCRIPTION
Promote python-flask-docker to version 0.0.6